### PR TITLE
chore: update up client

### DIFF
--- a/src/up/api.ts
+++ b/src/up/api.ts
@@ -198,6 +198,25 @@ export interface CashbackObject {
   amount: MoneyObject;
 }
 /**
+ * Uniquely identifies a category in the API.
+ * @export
+ * @interface CategoryInputResourceIdentifier
+ */
+export interface CategoryInputResourceIdentifier {
+  /**
+   * The type of this resource: `categories`
+   * @type {string}
+   * @memberof CategoryInputResourceIdentifier
+   */
+  type: string;
+  /**
+   * The unique identifier of the category, as returned by the `/categories` endpoint.
+   * @type {string}
+   * @memberof CategoryInputResourceIdentifier
+   */
+  id: string;
+}
+/**
  * Provides information about a category and its ancestry.
  * @export
  * @interface CategoryResource
@@ -828,6 +847,12 @@ export interface TransactionResourceAttributes {
    */
   message: string | null;
   /**
+   * Boolean flag set to true on transactions that support the use of categories.
+   * @type {boolean}
+   * @memberof TransactionResourceAttributes
+   */
+  isCategorizable: boolean;
+  /**
    * If this transaction is currently in the `HELD` status, or was ever in the `HELD` status, the `amount` and `foreignAmount` of the transaction while `HELD`.
    * @type {HoldInfoObject}
    * @memberof TransactionResourceAttributes
@@ -890,10 +915,10 @@ export interface TransactionResourceRelationships {
   transferAccount: TransactionResourceRelationshipsTransferAccount;
   /**
    *
-   * @type {CategoryResourceRelationshipsParent}
+   * @type {TransactionResourceRelationshipsCategory}
    * @memberof TransactionResourceRelationships
    */
-  category: CategoryResourceRelationshipsParent;
+  category: TransactionResourceRelationshipsCategory;
   /**
    *
    * @type {CategoryResourceRelationshipsParent}
@@ -948,6 +973,44 @@ export interface TransactionResourceRelationshipsAccountData {
 /**
  *
  * @export
+ * @interface TransactionResourceRelationshipsCategory
+ */
+export interface TransactionResourceRelationshipsCategory {
+  /**
+   *
+   * @type {CategoryResourceRelationshipsParentData}
+   * @memberof TransactionResourceRelationshipsCategory
+   */
+  data: CategoryResourceRelationshipsParentData | null;
+  /**
+   *
+   * @type {TransactionResourceRelationshipsCategoryLinks}
+   * @memberof TransactionResourceRelationshipsCategory
+   */
+  links?: TransactionResourceRelationshipsCategoryLinks;
+}
+/**
+ *
+ * @export
+ * @interface TransactionResourceRelationshipsCategoryLinks
+ */
+export interface TransactionResourceRelationshipsCategoryLinks {
+  /**
+   * The link to retrieve or modify linkage between this resources and the related resource(s) in this relationship.
+   * @type {string}
+   * @memberof TransactionResourceRelationshipsCategoryLinks
+   */
+  self: string;
+  /**
+   * The link to retrieve the related resource(s) in this relationship.
+   * @type {string}
+   * @memberof TransactionResourceRelationshipsCategoryLinks
+   */
+  related?: string;
+}
+/**
+ *
+ * @export
  * @interface TransactionResourceRelationshipsTags
  */
 export interface TransactionResourceRelationshipsTags {
@@ -997,7 +1060,7 @@ export interface TransactionResourceRelationshipsTagsLinks {
   self: string;
 }
 /**
- * If this transaction is a transfer between accounts, this field will contain the account the transaction went to/came from. The `amount` field can be used to determine the direction of the transfer.
+ * If this transaction is a transfer between accounts, this relationship will contain the account the transaction went to/came from. The `amount` field can be used to determine the direction of the transfer.
  * @export
  * @interface TransactionResourceRelationshipsTransferAccount
  */
@@ -1045,6 +1108,19 @@ export enum TransactionStatusEnum {
   Settled = "SETTLED",
 }
 
+/**
+ * Request to update the category associated with a transaction.
+ * @export
+ * @interface UpdateTransactionCategoryRequest
+ */
+export interface UpdateTransactionCategoryRequest {
+  /**
+   * The category to set on the transaction. Set this entire key to `null` de-categorize a transaction.
+   * @type {CategoryInputResourceIdentifier}
+   * @memberof UpdateTransactionCategoryRequest
+   */
+  data: CategoryInputResourceIdentifier | null;
+}
 /**
  * Request to add or remove tags associated with a transaction.
  * @export
@@ -1881,6 +1957,70 @@ export const CategoriesApiAxiosParamCreator = function (
         options: localVarRequestOptions,
       };
     },
+    /**
+     * Updates the category associated with a transaction. Only transactions for which `isCategorizable` is set to true support this operation. The `id` is taken from the list exposed on `/categories` and cannot be one of the top-level (parent) categories. To de-categorize a transaction, set the entire `data` key to `null`. An HTTP `204` is returned on success. The associated category, along with its request URL is also exposed via the `category` relationship on the transaction resource returned from `/transactions/{id}`.
+     * @summary Categorize transaction
+     * @param {string} transactionId The unique identifier for the transaction.
+     * @param {UpdateTransactionCategoryRequest} [updateTransactionCategoryRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    transactionsTransactionIdRelationshipsCategoryPatch: async (
+      transactionId: string,
+      updateTransactionCategoryRequest?: UpdateTransactionCategoryRequest,
+      options: AxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'transactionId' is not null or undefined
+      assertParamExists(
+        "transactionsTransactionIdRelationshipsCategoryPatch",
+        "transactionId",
+        transactionId
+      );
+      const localVarPath =
+        `/transactions/{transactionId}/relationships/category`.replace(
+          `{${"transactionId"}}`,
+          encodeURIComponent(String(transactionId))
+        );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = {
+        method: "PATCH",
+        ...baseOptions,
+        ...options,
+      };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication bearer_auth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      localVarHeaderParameter["Content-Type"] = "application/json";
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        updateTransactionCategoryRequest,
+        localVarRequestOptions,
+        configuration
+      );
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
   };
 };
 
@@ -1946,6 +2086,34 @@ export const CategoriesApiFp = function (configuration?: Configuration) {
         configuration
       );
     },
+    /**
+     * Updates the category associated with a transaction. Only transactions for which `isCategorizable` is set to true support this operation. The `id` is taken from the list exposed on `/categories` and cannot be one of the top-level (parent) categories. To de-categorize a transaction, set the entire `data` key to `null`. An HTTP `204` is returned on success. The associated category, along with its request URL is also exposed via the `category` relationship on the transaction resource returned from `/transactions/{id}`.
+     * @summary Categorize transaction
+     * @param {string} transactionId The unique identifier for the transaction.
+     * @param {UpdateTransactionCategoryRequest} [updateTransactionCategoryRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async transactionsTransactionIdRelationshipsCategoryPatch(
+      transactionId: string,
+      updateTransactionCategoryRequest?: UpdateTransactionCategoryRequest,
+      options?: AxiosRequestConfig
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.transactionsTransactionIdRelationshipsCategoryPatch(
+          transactionId,
+          updateTransactionCategoryRequest,
+          options
+        );
+      return createRequestFunction(
+        localVarAxiosArgs,
+        globalAxios,
+        BASE_PATH,
+        configuration
+      );
+    },
   };
 };
 
@@ -1990,6 +2158,27 @@ export const CategoriesApiFactory = function (
         .categoriesIdGet(id, options)
         .then((request) => request(axios, basePath));
     },
+    /**
+     * Updates the category associated with a transaction. Only transactions for which `isCategorizable` is set to true support this operation. The `id` is taken from the list exposed on `/categories` and cannot be one of the top-level (parent) categories. To de-categorize a transaction, set the entire `data` key to `null`. An HTTP `204` is returned on success. The associated category, along with its request URL is also exposed via the `category` relationship on the transaction resource returned from `/transactions/{id}`.
+     * @summary Categorize transaction
+     * @param {string} transactionId The unique identifier for the transaction.
+     * @param {UpdateTransactionCategoryRequest} [updateTransactionCategoryRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    transactionsTransactionIdRelationshipsCategoryPatch(
+      transactionId: string,
+      updateTransactionCategoryRequest?: UpdateTransactionCategoryRequest,
+      options?: any
+    ): AxiosPromise<void> {
+      return localVarFp
+        .transactionsTransactionIdRelationshipsCategoryPatch(
+          transactionId,
+          updateTransactionCategoryRequest,
+          options
+        )
+        .then((request) => request(axios, basePath));
+    },
   };
 };
 
@@ -2025,6 +2214,29 @@ export class CategoriesApi extends BaseAPI {
   public categoriesIdGet(id: string, options?: AxiosRequestConfig) {
     return CategoriesApiFp(this.configuration)
       .categoriesIdGet(id, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * Updates the category associated with a transaction. Only transactions for which `isCategorizable` is set to true support this operation. The `id` is taken from the list exposed on `/categories` and cannot be one of the top-level (parent) categories. To de-categorize a transaction, set the entire `data` key to `null`. An HTTP `204` is returned on success. The associated category, along with its request URL is also exposed via the `category` relationship on the transaction resource returned from `/transactions/{id}`.
+   * @summary Categorize transaction
+   * @param {string} transactionId The unique identifier for the transaction.
+   * @param {UpdateTransactionCategoryRequest} [updateTransactionCategoryRequest]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof CategoriesApi
+   */
+  public transactionsTransactionIdRelationshipsCategoryPatch(
+    transactionId: string,
+    updateTransactionCategoryRequest?: UpdateTransactionCategoryRequest,
+    options?: AxiosRequestConfig
+  ) {
+    return CategoriesApiFp(this.configuration)
+      .transactionsTransactionIdRelationshipsCategoryPatch(
+        transactionId,
+        updateTransactionCategoryRequest,
+        options
+      )
       .then((request) => request(this.axios, this.basePath));
   }
 }


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/Mause/proxy-up/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>npx @openapitools/openapi-generator-cli generate -i https://github.com/up-banking/api/raw/master/v1/openapi.json?apikey= -o src/up -g typescript-axios</em></summary>

```Shell
Download 5.3.0 ...
Downloaded 5.3.0
[main] INFO  o.o.codegen.DefaultGenerator - Generating with dryRun=false
[main] INFO  o.o.codegen.DefaultGenerator - OpenAPI Generator: typescript-axios (client)
[main] INFO  o.o.codegen.DefaultGenerator - Generator 'typescript-axios' is considered stable.
[main] INFO  o.o.c.l.AbstractTypeScriptClientCodegen - Hint: Environment variable 'TS_POST_PROCESS_FILE' (optional) not defined. E.g. to format the source code, please try 'export TS_POST_PROCESS_FILE="/usr/local/bin/prettier --write"' (Linux/Mac)
[main] INFO  o.o.c.l.AbstractTypeScriptClientCodegen - Note: To enable file post-processing, 'enablePostProcessFile' must be set to `true` (--enable-post-process-file for CLI).
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /accounts. Renamed to auto-generated operationId: accountsGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /accounts/{id}. Renamed to auto-generated operationId: accountsIdGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /categories. Renamed to auto-generated operationId: categoriesGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /categories/{id}. Renamed to auto-generated operationId: categoriesIdGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: patch /transactions/{transactionId}/relationships/category. Renamed to auto-generated operationId: transactionsTransactionIdRelationshipsCategoryPatch
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /util/ping. Renamed to auto-generated operationId: utilPingGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /tags. Renamed to auto-generated operationId: tagsGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: post /transactions/{transactionId}/relationships/tags. Renamed to auto-generated operationId: transactionsTransactionIdRelationshipsTagsPost
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: delete /transactions/{transactionId}/relationships/tags. Renamed to auto-generated operationId: transactionsTransactionIdRelationshipsTagsDelete
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /transactions. Renamed to auto-generated operationId: transactionsGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /transactions/{id}. Renamed to auto-generated operationId: transactionsIdGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /accounts/{accountId}/transactions. Renamed to auto-generated operationId: accountsAccountIdTransactionsGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /webhooks. Renamed to auto-generated operationId: webhooksGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: post /webhooks. Renamed to auto-generated operationId: webhooksPost
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: post Event_{webhookURL}. Renamed to auto-generated operationId: event_webhookURLPost
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /webhooks/{id}. Renamed to auto-generated operationId: webhooksIdGet
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: delete /webhooks/{id}. Renamed to auto-generated operationId: webhooksIdDelete
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: post /webhooks/{webhookId}/ping. Renamed to auto-generated operationId: webhooksWebhookIdPingPost
[main] WARN  o.o.codegen.DefaultCodegen - Empty operationId found for path: get /webhooks/{webhookId}/logs. Renamed to auto-generated operationId: webhooksWebhookIdLogsGet
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/index.ts
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/base.ts
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/common.ts
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/api.ts
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/configuration.ts
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/git_push.sh
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/.gitignore
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/.npmignore
[main] INFO  o.o.codegen.TemplateManager - Skipped /home/runner/work/proxy-up/proxy-up/src/up/.openapi-generator-ignore (Skipped by supportingFiles options supplied by user.)
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/.openapi-generator/VERSION
[main] INFO  o.o.codegen.TemplateManager - writing file /home/runner/work/proxy-up/proxy-up/src/up/.openapi-generator/FILES
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
```



</details>
<details>
<summary><em>npx prettier . --write</em></summary>

```Shell
__tests__/simple.ts 55ms
.eslintrc.yml 28ms
.github/dependabot.yml 6ms
.github/workflows/build.yaml 8ms
.github/workflows/generate-client.yaml 12ms
.pre-commit-config.yaml 8ms
api/openapi.yaml 15ms
api/up.ts 62ms
jest.config.js 20ms
openapitools.json 3ms
package.json 4ms
public/index.html 22ms
README.md 20ms
renovate.json 2ms
src/authenticate.ts 11ms
src/up/api.ts 620ms
src/up/base.ts 54ms
src/up/common.ts 24ms
src/up/configuration.ts 14ms
src/up/index.ts 6ms
support/log.ts 8ms
tsconfig.json 8ms
vercel.json 3ms
```

### stderr:

```Shell
npx: installed 1 in 1.211s
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- src/up/api.ts

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)